### PR TITLE
Fix crash when there are trailing spaces in the host name

### DIFF
--- a/c/parser/hosts.c
+++ b/c/parser/hosts.c
@@ -68,7 +68,7 @@ void NLPERMANENTMARKERSHOSTS_chostentry_destroy(NLPERMANENTMARKERSHOSTS_CHostEnt
 int NLPERMANENTMARKERSHOSTS_parsed_value_equals(const char * value, int target) {
     int result = 0;
     yyscan_t scanner;
-    YYSTYPE NLPERMANENTMARKERSHOSTSlval;
+    YYSTYPE NLPERMANENTMARKERSHOSTSlval={};
     NLPERMANENTMARKERSHOSTSlex_init( &scanner );
     YY_BUFFER_STATE handle = NLPERMANENTMARKERSHOSTS_scan_string(value, scanner);
     if (NLPERMANENTMARKERSHOSTSlex(&NLPERMANENTMARKERSHOSTSlval, scanner) == target && strcmp(NLPERMANENTMARKERSHOSTSlval.string, value) == 0) {


### PR DESCRIPTION
If you enter trailing spaces in the host name, the pref pane can crash. It happens every time for me, but I suppose there's a chance it might not for everybody. The attached pull request seems to fix it.
